### PR TITLE
Add GitHub Action for CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,40 @@
+name: CI for Tekton Install
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.13
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Get dependencies
+      run: |
+        go get -v -t -d ./...
+        if [ -f Gopkg.toml ]; then
+            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+            dep ensure
+        fi
+
+    - name: Build
+      run: | 
+        go build -v .
+        ./tekton-install
+
+    - name: Test
+      run: go test -v ./...


### PR DESCRIPTION
Adding GitHub actions that will serve as CI:
* Builds `tekton-install`
* Runs unit tests

Future things to add:
* Code coverage
* Linting
* e2e scenario against Minikube or KinD to test install command