### PR TITLE
e2e tests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -38,3 +38,21 @@ jobs:
 
     - name: Test
       run: go test -v ./...
+    
+    - name: Create KinD cluster
+      uses: engineerd/setup-kind@v0.4.0
+      with:
+          version: "v0.8.0"
+
+    - name: e2e-install
+      run: |
+        kubectl cluster-info
+        
+        echo "Running tekton-install install test"
+        ./tekton-install install pipeline triggers dashboard
+
+        echo "Waiting for Pods to become available in tekton-pipelines namespace"
+        kubectl wait --for=condition=Ready pod -n tekton-pipelines --timeout=3m --all
+
+        echo "Showing available Pods in tekton-pipelines namespace"
+        kubectl get pods -n tekton-pipelines


### PR DESCRIPTION
This pull request adds an e2e test for the `tekton-install install` command. A KinD cluster is created for each CI run and `tekton-install pipeline triggers dashboard` is run against the clusters. `kubectl wait` is used to verify that Pods become available in the `tekton-pipelines` namespace on the cluster.