### PR TITLE
Add Uninstall Command

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -44,7 +44,7 @@ jobs:
       with:
           version: "v0.8.0"
 
-    - name: e2e-install
+    - name: e2e
       run: |
         kubectl cluster-info
         
@@ -55,4 +55,10 @@ jobs:
         kubectl wait --for=condition=Ready pod -n tekton-pipelines --timeout=3m --all
 
         echo "Showing available Pods in tekton-pipelines namespace"
+        kubectl get pods -n tekton-pipelines
+        
+        echo "Running tekton-install uninstall test"
+        ./tekton-install uninstall triggers dashboard pipeline
+
+        echo "Showing available Pods in tekton-pipelines namespace after uninstall"
         kubectl get pods -n tekton-pipelines

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -50,7 +50,7 @@ tekton-install install all
 tekton-install install all --pipeline-version 0.15.0 --triggers-version 0.6.0 --dashboard-version 0.6.0`,
 	Args: cobra.RangeArgs(1, 3),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := validateArgsInstall(args); err != nil {
+		if err := validateArgs(args); err != nil {
 			return err
 		}
 
@@ -103,7 +103,7 @@ func install(args []string) error {
 	return nil
 }
 
-func validateArgsInstall(args []string) error {
+func validateArgs(args []string) error {
 	validComponents := make(map[string]bool)
 	validComponents[pipeline] = true
 	validComponents[triggers] = true
@@ -112,7 +112,7 @@ func validateArgsInstall(args []string) error {
 
 	for _, arg := range args {
 		if !validComponents[arg] {
-			return fmt.Errorf("invalid argument provided to install command: %s", arg)
+			return fmt.Errorf("invalid argument provided to command: %s", arg)
 		}
 
 		if arg == "all" && args[0] != "all" {

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 func Test_validateArgsInstall_Invalid_Argument(t *testing.T) {
-	expectedErr := "invalid argument provided to install command: invalid"
-	err := validateArgsInstall([]string{"invalid", "pipeline"})
+	expectedErr := "invalid argument provided to command: invalid"
+	err := validateArgs([]string{"invalid", "pipeline"})
 	if err == nil {
 		t.Error("expecting error from invalid argument passed to validateArgsInstall but no error returned")
 	}
@@ -20,7 +20,7 @@ func Test_validateArgsInstall_Invalid_Argument(t *testing.T) {
 
 func Test_validateArgsInstall_Invalid_AllNotFirst(t *testing.T) {
 	expectedErr := "all should be only argument provided when used"
-	err := validateArgsInstall([]string{"pipeline", "all"})
+	err := validateArgs([]string{"pipeline", "all"})
 	if err == nil {
 		t.Error("expecting error from all argument used with additional arguments but no error returned")
 	}
@@ -31,14 +31,14 @@ func Test_validateArgsInstall_Invalid_AllNotFirst(t *testing.T) {
 }
 
 func Test_validateArgsInstall_Valid_AllValidArgsPassed(t *testing.T) {
-	err := validateArgsInstall([]string{"pipeline", "triggers", "dashboard"})
+	err := validateArgs([]string{"pipeline", "triggers", "dashboard"})
 	if err != nil {
 		t.Errorf("no error expected but error was returned: %v", err)
 	}
 }
 
 func Test_validateArgsInstall_Valid_SingleArgPassed(t *testing.T) {
-	err := validateArgsInstall([]string{"pipeline"})
+	err := validateArgs([]string{"pipeline"})
 	if err != nil {
 		t.Errorf("no error expected but error was returned: %v", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,8 +6,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var cfgFile string
-
 var rootCmd = &cobra.Command{
 	Use:          "tekton-install",
 	Short:        "A CLI for installing Tekton and associated components",

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	components = []string{triggers, dashboard, pipeline}
+)
+
+var uninstallCmd = &cobra.Command{
+	Use:   "uninstall",
+	Short: "Uninstall various components of Tekton",
+	Long: `Uninstall the pipeline, triggers, and dashboard components. 
+
+# Uninstall the Tekton pipeline component
+# NOTE: Uninstalling pipeline component will
+# also uninstall other installed Tekton components
+tekton-install uninstall pipeline
+
+# Uninstall the Tekton triggers component
+tekton-install uninstall triggers
+
+# Uninstall the Tekton dashboard component
+tekton-install uninstall dashboard
+
+# Uninstall all Tekton components
+tekton-install uninstall all`,
+	Args: cobra.RangeArgs(1, 3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return uninstall(args)
+	},
+}
+
+func uninstall(args []string) error {
+	if err := validateArgs(args); err != nil {
+		return err
+	}
+
+	var allArgs []string
+	all := false
+	if args[0] == "all" {
+		allArgs = components
+		all = true
+	} else {
+		allArgs = args
+	}
+
+	componentVersions := make(map[string]string)
+	for _, arg := range allArgs {
+		version, err := getComponentVersion(arg, all)
+		if err != nil {
+			return err
+		}
+		if version != "" {
+			componentVersions[arg] = version
+		}
+	}
+
+	return uninstallComponents(componentVersions)
+}
+
+func getComponentVersion(component string, all bool) (string, error) {
+	if component != dashboard {
+		// Since deployment for pipeline is named tekton-pipelines-controller, reassign component name to pipelines
+		if component == pipeline {
+			component = "pipelines"
+		}
+
+		argv := []string{"get", "deployment/tekton-" + component + "-controller", "-o", "jsonpath={.metadata.labels['app\\.kubernetes\\.io/version']}", "-n", "tekton-pipelines"}
+		kubectlCmd := exec.Command("kubectl", argv...)
+		kubectlCmd.Env = os.Environ()
+		kubectlCmd.Stderr = os.Stderr
+
+		version, err := kubectlCmd.Output()
+		if err != nil {
+			if all {
+				return "", nil
+			}
+
+			return "", fmt.Errorf("failed to get version of component %s", component)
+		}
+
+		return string(version), nil
+	}
+
+	argv := []string{"get", "deployment/tekton-" + component, "-o", "jsonpath={.metadata.labels.version}", "-n", "tekton-pipelines"}
+	kubectlCmd := exec.Command("kubectl", argv...)
+	kubectlCmd.Env = os.Environ()
+	kubectlCmd.Stderr = os.Stderr
+
+	version, err := kubectlCmd.Output()
+	if err != nil {
+		if all {
+			return "", nil
+		}
+
+		return "", fmt.Errorf("failed to get version of component %s", component)
+	}
+
+	return string(version), nil
+}
+
+func uninstallComponents(componentVersions map[string]string) error {
+	for _, component := range components {
+		argv := []string{}
+		if _, ok := componentVersions[component]; ok {
+			if component != dashboard {
+				argv = []string{"delete", "-f", "https://storage.googleapis.com/tekton-releases/" + component + "/previous/" + componentVersions[component] + "/release.yaml"}
+			} else {
+				argv = []string{"delete", "-f", "https://storage.googleapis.com/tekton-releases/" + component + "/previous/" + componentVersions[component] + "/tekton-dashboard-release.yaml"}
+			}
+			kubectlCmd := exec.Command("kubectl", argv...)
+			kubectlCmd.Env = os.Environ()
+			kubectlCmd.Stderr = os.Stderr
+			if err := kubectlCmd.Run(); err != nil {
+				return fmt.Errorf("uninstall of %s has failed", component)
+			}
+			fmt.Printf("Component %s has been uninstalled successfully\n", component)
+		}
+	}
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(uninstallCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/danielhelfand/tekton-install
 go 1.14
 
 require (
-	github.com/google/go-cmp v0.2.0
+	github.com/google/go-cmp v0.5.0
 	github.com/spf13/cobra v1.0.0
+	github.com/spf13/pflag v1.0.5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -14,11 +14,13 @@ github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
@@ -34,6 +36,8 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
+github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
@@ -89,6 +93,8 @@ github.com/spf13/jwalterweatherman v1.0.0 h1:XHEdyB+EcvlqZamSM4ZOMGlc93t6AcsBEu9
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -123,6 +129,8 @@ golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=


### PR DESCRIPTION
Adding an uninstall command to uninstall Tekton components available on a Kubernetes cluster. The command uses `kubectl` to figure out what versions of Tekton components are installed and passes the version to a `kubectl delete -f` command to remove installed components. 

Future considerations:
* A prompt message to confirm with users if they want to uninstall components before proceeding
* A `--force` flag to override the confirmation prompt