### PR TITLE
Move validateArgs and components to separate files

### DIFF
--- a/cmd/components.go
+++ b/cmd/components.go
@@ -1,0 +1,7 @@
+package cmd
+
+const (
+	pipeline  = "pipeline"
+	dashboard = "dashboard"
+	triggers  = "triggers"
+)

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -14,12 +14,6 @@ var (
 	dashboardVersion string
 )
 
-const (
-	pipeline  = "pipeline"
-	dashboard = "dashboard"
-	triggers  = "triggers"
-)
-
 var installCmd = &cobra.Command{
 	Use:   "install",
 	Short: "Install various components of Tekton",
@@ -100,25 +94,6 @@ func install(args []string) error {
 		fmt.Printf("Component %s has been installed successfully\n", arg)
 	}
 
-	return nil
-}
-
-func validateArgs(args []string) error {
-	validComponents := make(map[string]bool)
-	validComponents[pipeline] = true
-	validComponents[triggers] = true
-	validComponents[dashboard] = true
-	validComponents["all"] = true
-
-	for _, arg := range args {
-		if !validComponents[arg] {
-			return fmt.Errorf("invalid argument provided to command: %s", arg)
-		}
-
-		if arg == "all" && args[0] != "all" {
-			return fmt.Errorf("all should be only argument provided when used")
-		}
-	}
 	return nil
 }
 

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -1,0 +1,22 @@
+package cmd
+
+import "fmt"
+
+func validateArgs(args []string) error {
+	validComponents := make(map[string]bool)
+	validComponents[pipeline] = true
+	validComponents[triggers] = true
+	validComponents[dashboard] = true
+	validComponents["all"] = true
+
+	for _, arg := range args {
+		if !validComponents[arg] {
+			return fmt.Errorf("invalid argument provided to command: %s", arg)
+		}
+
+		if arg == "all" && args[0] != "all" {
+			return fmt.Errorf("all should be only argument provided when used")
+		}
+	}
+	return nil
+}

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func Test_validateArgsInstall_Invalid_Argument(t *testing.T) {
+func Test_validateArgs_Invalid_Argument(t *testing.T) {
 	expectedErr := "invalid argument provided to command: invalid"
 	err := validateArgs([]string{"invalid", "pipeline"})
 	if err == nil {
@@ -18,7 +18,7 @@ func Test_validateArgsInstall_Invalid_Argument(t *testing.T) {
 	}
 }
 
-func Test_validateArgsInstall_Invalid_AllNotFirst(t *testing.T) {
+func Test_validateArgs_Invalid_AllNotFirst(t *testing.T) {
 	expectedErr := "all should be only argument provided when used"
 	err := validateArgs([]string{"pipeline", "all"})
 	if err == nil {
@@ -30,14 +30,14 @@ func Test_validateArgsInstall_Invalid_AllNotFirst(t *testing.T) {
 	}
 }
 
-func Test_validateArgsInstall_Valid_AllValidArgsPassed(t *testing.T) {
+func Test_validateArgs_Valid_AllValidArgsPassed(t *testing.T) {
 	err := validateArgs([]string{"pipeline", "triggers", "dashboard"})
 	if err != nil {
 		t.Errorf("no error expected but error was returned: %v", err)
 	}
 }
 
-func Test_validateArgsInstall_Valid_SingleArgPassed(t *testing.T) {
+func Test_validateArgs_Valid_SingleArgPassed(t *testing.T) {
 	err := validateArgs([]string{"pipeline"})
 	if err != nil {
 		t.Errorf("no error expected but error was returned: %v", err)


### PR DESCRIPTION
Both install/uninstall rely on `validateArgs` and the components consts, so moving them into separate files to improve organization. 