### PR TITLE
Fix Error Message for when Components are not Installed

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,5 +17,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.29
+          version: v1.31
           args: -v

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -61,45 +61,34 @@ func uninstall(args []string) error {
 		}
 	}
 
+	if len(componentVersions) == 0 {
+		fmt.Println("No components on cluster to uninstall")
+		return nil
+	}
+
 	return uninstallComponents(componentVersions)
 }
 
 func getComponentVersion(component string, all bool) (string, error) {
+	var argv []string
 	if component != dashboard {
 		// Since deployment for pipeline is named tekton-pipelines-controller, reassign component name to pipelines
 		if component == pipeline {
 			component = "pipelines"
 		}
-
-		argv := []string{"get", "deployment/tekton-" + component + "-controller", "-o", "jsonpath={.metadata.labels['app\\.kubernetes\\.io/version']}", "-n", "tekton-pipelines"}
-		kubectlCmd := exec.Command("kubectl", argv...)
-		kubectlCmd.Env = os.Environ()
-		kubectlCmd.Stderr = os.Stderr
-
-		version, err := kubectlCmd.Output()
-		if err != nil {
-			if all {
-				return "", nil
-			}
-
-			return "", fmt.Errorf("failed to get version of component %s", component)
-		}
-
-		return string(version), nil
+		argv = []string{"get", "deployment/tekton-" + component + "-controller", "-o", "jsonpath={.metadata.labels['app\\.kubernetes\\.io/version']}", "-n", "tekton-pipelines"}
+	} else {
+		argv = []string{"get", "deployment/tekton-" + component, "-o", "jsonpath={.metadata.labels.version}", "-n", "tekton-pipelines"}
 	}
 
-	argv := []string{"get", "deployment/tekton-" + component, "-o", "jsonpath={.metadata.labels.version}", "-n", "tekton-pipelines"}
 	kubectlCmd := exec.Command("kubectl", argv...)
-	kubectlCmd.Env = os.Environ()
-	kubectlCmd.Stderr = os.Stderr
-
 	version, err := kubectlCmd.Output()
 	if err != nil {
 		if all {
 			return "", nil
 		}
 
-		return "", fmt.Errorf("failed to get version of component %s", component)
+		return "", fmt.Errorf("failed to get version of component %s, check if it is installed", component)
 	}
 
 	return string(version), nil


### PR DESCRIPTION
Closes #9 

Removing printing of errors to stderr for getComponentVersions. If the component is not present when running `tekton-install uninstall all`, simply ignore the error and try to find other specified components.

Miscellaneous:
* Refactor getComponentVersions to simplify it
* Bump golangci-lint to 1.31
* Change error message when uninstalling non present component