### PR TITLE
List Components in Consistent Order

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -13,6 +13,10 @@ const (
 	body   = "%s\t%s\n"
 )
 
+var (
+	componentsSorted = []string{dashboard, pipeline, triggers}
+)
+
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List installed Tekton components on a Kubernetes cluster",
@@ -42,8 +46,11 @@ func list(componentVersions map[string]string) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 5, 3, ' ', tabwriter.TabIndent)
 	fmt.Fprintln(w, header)
 
-	for component, version := range componentVersions {
-		fmt.Fprintf(w, body, component, version)
+	for _, component := range componentsSorted {
+		version, ok := componentVersions[component]
+		if ok {
+			fmt.Fprintf(w, body, component, version)
+		}
 	}
 
 	w.Flush()


### PR DESCRIPTION
Closes #16 

Have a list of components in a pre-sorted order instead of iterating over map in `list()` func. 