### PR TITLE
Remove String Conversion from e2e Test

### DIFF
--- a/test/e2e/list_test.go
+++ b/test/e2e/list_test.go
@@ -80,7 +80,7 @@ func Test_List_Command(t *testing.T) {
 			t.Log(errMsg)
 		}
 
-		if d := cmp.Diff(string(output), noComponentsMsg); d != "" {
+		if d := cmp.Diff(output, noComponentsMsg); d != "" {
 			t.Fatalf("-got, +want: %v", d)
 		}
 	})


### PR DESCRIPTION
`output` should already be a string. When originally developing this, the method returned a `[]byte` from `command.Output()`. This wasn't properly changed after the func signature change.