### PR TITLE
Add --timeout Option for Uninstall

### DIFF
--- a/test/e2e/test_functions.go
+++ b/test/e2e/test_functions.go
@@ -37,14 +37,14 @@ func setCommandStdOutErr(command *exec.Cmd, stdout, stderr *bytes.Buffer) {
 
 func runCommand(command *exec.Cmd) {
 	if err := command.Run(); err != nil {
-		log.Fatalf("command %s failed", command.Args)
+		log.Printf("command %s failed", command.Args)
 	}
 }
 
 func runCommandOutput(command *exec.Cmd, stdout, stderr *bytes.Buffer) (string, string) {
 	err := command.Run()
 	if err != nil {
-		log.Fatalf("command %s failed", command.Args)
+		log.Printf("command %s failed", command.Args)
 	}
 
 	return stdout.String(), stderr.String()


### PR DESCRIPTION
Closes #21 

This pull request adds a `--timeout` option for `tekton-install uninstall` to allow for timeout to be configurable. This only puts in place timeout for each `kubectl delete -f` command. It is not a timeout for `tekton-install uninstall`, but for each `kubectl delete -f` command. By default, the timeout is 0, which is the default for `kubectl`.