### PR TITLE
Add Validation for triggers/dashboard Installs

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -48,6 +48,17 @@ tekton-install install all --pipeline-version 0.15.0 --triggers-version 0.6.0 --
 			return err
 		}
 
+		firstArg := args[0]
+		if firstArg != pipeline && firstArg != "all" {
+			// Check if pipeline is installed. Needs to
+			// be installed if tiggers/dashboard are only
+			// components being installed.
+			_, err := getComponentVersion(pipeline, false)
+			if err != nil {
+				return fmt.Errorf("%s component must be installed to install %s or %s", pipeline, triggers, dashboard)
+			}
+		}
+
 		return install(args)
 	},
 }

--- a/test/e2e/install_uninstall_test.go
+++ b/test/e2e/install_uninstall_test.go
@@ -18,6 +18,19 @@ const (
 )
 
 func Test_Install_Uninstall_Commands(t *testing.T) {
+	t.Run("Error from install of triggers/dashboard without pipeline installed", func(t *testing.T) {
+		argv := []string{"install", "triggers", "dashboard"}
+		output, errMsg := ExecuteCommandOutput(TektonInstallCmd, argv, true)
+		if errMsg == "" {
+			t.Logf("Expected error from installing components without pipeline installed but received output:\n%s", output)
+		}
+
+		expected := "Error: pipeline component must be installed to install triggers or dashboard\n"
+		if d := cmp.Diff(errMsg, expected); d != "" {
+			t.Fatalf("-got, +want: %v", d)
+		}
+	})
+
 	t.Run("Install pipeline component", func(t *testing.T) {
 		argv := []string{"install", "pipeline"}
 		output, errMsg := ExecuteCommandOutput(TektonInstallCmd, argv, false)


### PR DESCRIPTION
This pull request adds validation for the `tekton-install install` command for installing triggers/dashboard. Both components rely on pipeline already being installed.