### PR TITLE
Add Version Command

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	version = "v0.0.1"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Show the version of tekton-install",
+	Long: `Show the version of tekton-install.
+
+# Show version of tekton-install
+tekton-install version`,
+	Args: cobra.ExactArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Fprintln(cmd.OutOrStdout(), version)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func Test_version(t *testing.T) {
+	stdout := bytes.NewBufferString("")
+	rootCmd.SetOut(stdout)
+	rootCmd.SetArgs([]string{"version"})
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("Error from executing version command: %v", err)
+	}
+
+	out, err := ioutil.ReadAll(stdout)
+	if err != nil {
+		t.Fatalf("Error from reading version command stdout: %v", err)
+	}
+
+	expected := version + "\n"
+	if d := cmp.Diff(string(out), expected); d != "" {
+		t.Fatalf("-got, +want: %v", d)
+	}
+}

--- a/test/e2e/version_test.go
+++ b/test/e2e/version_test.go
@@ -1,0 +1,24 @@
+// +build e2e
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func Test_Version_Command(t *testing.T) {
+	t.Run("Run version command", func(t *testing.T) {
+		argv := []string{"version"}
+		output, errMsg := ExecuteCommandOutput(TektonInstallCmd, argv, false)
+		if errMsg != "" {
+			t.Log(errMsg)
+		}
+
+		version := "v0.0.1\n"
+		if d := cmp.Diff(output, version); d != "" {
+			t.Fatalf("-got, +want: %v", d)
+		}
+	})
+}


### PR DESCRIPTION
Closes #34 

This pull request adds a `tekton-install version` command to print the version of `tekton-install`. The initial version will be `v0.0.1`. 