### PR TITLE
Adding goreleaser Config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,31 @@
+builds:
+  - env:
+      - CGO_ENABLED=0
+    binary: tekton-install
+    goos:
+      - linux
+      - windows
+      - darwin
+archives:
+- name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+  format_overrides:
+   - goos: windows
+     format: zip
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+release:
+  prerelease: true


### PR DESCRIPTION
Adding `goreleaser.yml` to assist with releasing versions of `tekton-install`.