### PR TITLE
update setup-kind version

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,7 +39,7 @@ jobs:
       run: go test -v ./...
     
     - name: Create KinD cluster
-      uses: engineerd/setup-kind@v0.4.0
+      uses: engineerd/setup-kind@v0.5.0
       with:
           version: "v0.8.0"
 


### PR DESCRIPTION
Fixes https://github.com/danielhelfand/tekton-install/issues/48

The latest version of the action updated its dependencies, which should fix the build failure.